### PR TITLE
Users from LDAP groups that contain escaped characters are not proper…

### DIFF
--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
@@ -30,6 +30,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -909,6 +911,12 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
 
                 Set<String> ldapGroupsSetToAdd = new HashSet<String>(Arrays.asList(ldapGroupsArray));
                 Map<String, Set<String>> groupMapping = getConfiguration().getGroupMappings();
+                for (String key : groupMapping.keySet()) {
+                    Set<String> modifiedSet =
+                        groupMapping.get(key).stream().map((value) -> StringUtils.replace(value, "\\", "\\\\"))
+                            .collect(Collectors.toSet());
+                    groupMapping.put(key, modifiedSet);
+                }
                 Set<String> ldapGroupsSet = new HashSet<>();
                 if (groupMapping.get(xWikiGroupName) != null) {
                     ldapGroupsSet.addAll(groupMapping.get(xWikiGroupName));

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
@@ -911,11 +911,11 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
 
                 Set<String> ldapGroupsSetToAdd = new HashSet<String>(Arrays.asList(ldapGroupsArray));
                 Map<String, Set<String>> groupMapping = getConfiguration().getGroupMappings();
-                for (String key : groupMapping.keySet()) {
+                for (Entry<String, Set<String>> entry : groupMapping.entrySet()) {
                     Set<String> modifiedSet =
-                        groupMapping.get(key).stream().map((value) -> StringUtils.replace(value, "\\", "\\\\"))
+                        entry.getValue().stream().map((value) -> StringUtils.replace(value, "\\", "\\\\"))
                             .collect(Collectors.toSet());
-                    groupMapping.put(key, modifiedSet);
+                    entry.setValue(modifiedSet);
                 }
                 Set<String> ldapGroupsSet = new HashSet<>();
                 if (groupMapping.get(xWikiGroupName) != null) {

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
@@ -706,6 +706,16 @@
   var searchLoading = $('#groupSearchResultsLoading');
   var associateResultsLoading = $('#associateResultsLoading');
   var associateButton = $('#associateButton');
+  var escape = function (str) {
+    let result = '';
+    for (var i = str.length - 1; i &gt;= 0; i--) {
+      result = str[i] + result;
+      if (str[i] === '\\' || (str[i] === '|' &amp;&amp; str[i-1] !== '\\')) {
+        result = '\\' + result;
+      }
+    }
+    return result;
+  };
 
   // Set the XWiki group name in the associateLDAPGroups form
   $('#groupstable').on('click', '.actionassociategroups', function() {
@@ -756,12 +766,13 @@
             listItem.html(displayedText);
             itemCSSClass = 'associated';
           } else {
+            let escapedValue = escape(value.dn);
             displayAssociateButton = true;
             var checkbox = $('&lt;input/&gt;').attr({
               'type': 'checkbox',
               'name': 'group',
               'id': index,
-              'value': value['dn']
+              'value': escapedValue
             });
             var label = $('&lt;label/&gt;').attr({
               'for': index,

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
@@ -706,16 +706,6 @@
   var searchLoading = $('#groupSearchResultsLoading');
   var associateResultsLoading = $('#associateResultsLoading');
   var associateButton = $('#associateButton');
-  var escape = function (str) {
-    let result = '';
-    for (var i = str.length - 1; i &gt;= 0; i--) {
-      result = str[i] + result;
-      if (str[i] === '\\' || (str[i] === '|' &amp;&amp; str[i-1] !== '\\')) {
-        result = '\\' + result;
-      }
-    }
-    return result;
-  };
 
   // Set the XWiki group name in the associateLDAPGroups form
   $('#groupstable').on('click', '.actionassociategroups', function() {
@@ -766,7 +756,7 @@
             listItem.html(displayedText);
             itemCSSClass = 'associated';
           } else {
-            let escapedValue = escape(value.dn);
+            let escapedValue = value.dn.replaceAll('\\', '\\\\');
             displayAssociateButton = true;
             var checkbox = $('&lt;input/&gt;').attr({
               'type': 'checkbox',

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <name>LDAP User Import Application - Parent POM</name>
   <description>Application to import users from LDAP</description>
   <properties>
-    <ldap.version>9.5.6</ldap.version>
+    <ldap.version>9.5.8</ldap.version>
   </properties>
   <issueManagement>
     <system>GitHub</system>


### PR DESCRIPTION
…ly mapped on log in #53

* Double the backslashes of the LDAP groups returned by the search action
* When retrieving the group mappings using XWikiLDAPConfig.getGroupMappings, make sure to double the backslashes if you intend to modify and persist it