### PR TITLE
#63 : Provide a configuration API

### DIFF
--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.ldapuserimport;
+
+import java.util.List;
+
+import org.xwiki.component.annotation.Role;
+
+/**
+ * Configuration for the LDAP User Import application.
+ *
+ * @version $Id$
+ * @since 1.3
+ */
+@Role
+public interface LDAPUserImportConfiguration
+{
+    /**
+     * Define who is allowed to import LDAP users in the wiki.
+     */
+    enum UserImportPolicy {
+        /**
+         * Only allow global administrators.
+         */
+        GLOBAL_ADMINS,
+
+        /**
+         * Allow both global and local wiki administrators to import users.
+         */
+        GLOBAL_AND_LOCAL_ADMINS,
+
+        /**
+         * Allow anyone able to edit a group to import users.
+         */
+        GROUP_EDITORS
+    }
+
+    /**
+     * @return the list of LDAP user attributes
+     */
+    List<String> getLDAPUserAttributes();
+
+    /**
+     * @return true if user search should be perfromed on a single LDAP field in the UI
+     */
+    boolean getEnableSingleFieldSearch();
+
+    /**
+     * @return true if a OIDC Object should be added to new user profiles upon import
+     * @see {{@link #getOIDCIssuer()}}
+     */
+    boolean getAddOIDCObject();
+
+    /**
+     * @return the OIDC issuer to be provided when an OIDC Object should be added to new user profiles upon import
+     * @see {{@link #getAddOIDCObject()}}
+     */
+    String getOIDCIssuer();
+
+    /**
+     * @return the user import policy
+     */
+    UserImportPolicy getUserImportPolicy();
+
+    /**
+     * @return the format to be used for new user page names.
+     */
+    String getUserPageNameFormatter();
+
+    /**
+     * @return the maximum number of users to be displayed in the import wizard
+     */
+    int getMaxUserImportWizardResults();
+
+    /**
+     * @return true if groups should be updated on synchronization
+     */
+    boolean getTriggerGroupUpdate();
+
+    /**
+     * @return true if user group membership should be updated upon synchronization
+     */
+    boolean getForceUserGroupMembershipUpdate();
+}

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -27,7 +27,7 @@ import org.xwiki.component.annotation.Role;
  * Configuration for the LDAP User Import application.
  *
  * @version $Id$
- * @since 1.3
+ * @since 1.4
  */
 @Role
 public interface LDAPUserImportConfiguration
@@ -35,7 +35,8 @@ public interface LDAPUserImportConfiguration
     /**
      * Define who is allowed to import LDAP users in the wiki.
      */
-    enum UserImportPolicy {
+    enum UserImportPolicy
+    {
         /**
          * Only allow global administrators.
          */

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
@@ -25,9 +25,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 
@@ -41,8 +43,10 @@ import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
  * Default implementation of the {@link LDAPUserImportConfiguration}.
  *
  * @version $Id$
- * @since 1.3
+ * @since 1.4
  */
+@Component
+@Singleton
 public class DefaultLDAPUserImportConfiguration implements LDAPUserImportConfiguration
 {
     private static final String LDAP_USER_IMPORT = "LDAPUserImport";

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
@@ -1,0 +1,153 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.ldapuserimport.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
+
+/**
+ * Default implementation of the {@link LDAPUserImportConfiguration}.
+ *
+ * @version $Id$
+ * @since 1.3
+ */
+public class DefaultLDAPUserImportConfiguration implements LDAPUserImportConfiguration
+{
+    private static final String LDAP_USER_IMPORT = "LDAPUserImport";
+
+    private static final DocumentReference CONFIGURATION_REFERENCE =
+        new DocumentReference("xwiki", LDAP_USER_IMPORT, "WebHome");
+
+    private static final LocalDocumentReference CONFIGURATION_CLASS_REFERENCE =
+        new LocalDocumentReference(LDAP_USER_IMPORT, "LDAPUserImportConfigClass");
+
+    private static final int DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS = 20;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public List<String> getLDAPUserAttributes()
+    {
+        BaseObject object = getObject();
+        return object != null ? Arrays.asList(object.getStringValue("ldapUserAttributes").split(","))
+            : Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean getEnableSingleFieldSearch()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("enableSingleFieldSearch") == 1;
+    }
+
+    @Override
+    public boolean getAddOIDCObject()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("addOIDCObject") == 1;
+    }
+
+    @Override
+    public String getOIDCIssuer()
+    {
+        BaseObject object = getObject();
+        return (object != null) ? object.getStringValue("OIDCIssuer") : StringUtils.EMPTY;
+    }
+
+    @Override
+    public UserImportPolicy getUserImportPolicy()
+    {
+        BaseObject object = getObject();
+
+        if (object != null) {
+            String value = object.getStringValue("usersAllowedToImport");
+
+            if ("localAdmin".equals(value)) {
+                return UserImportPolicy.GLOBAL_AND_LOCAL_ADMINS;
+            } else if ("groupEditor".equals(value)) {
+                return UserImportPolicy.GROUP_EDITORS;
+            }
+        }
+
+        return UserImportPolicy.GLOBAL_ADMINS;
+    }
+
+    @Override
+    public String getUserPageNameFormatter()
+    {
+        BaseObject object = getObject();
+        return (object != null) ? object.getStringValue("pageNameFormatter") : StringUtils.EMPTY;
+    }
+
+    @Override
+    public int getMaxUserImportWizardResults()
+    {
+        BaseObject object = getObject();
+        return (object != null) ? object.getIntValue("resultsNumber", DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS)
+            : DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS;
+    }
+
+    @Override
+    public boolean getTriggerGroupUpdate()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("triggerGroupsUpdate") == 1;
+    }
+
+    @Override
+    public boolean getForceUserGroupMembershipUpdate()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("forceXWikiUsersGroupMembershipUpdate") == 1;
+    }
+
+    private BaseObject getObject()
+    {
+        XWikiContext context = contextProvider.get();
+        XWikiDocument importConfigDoc;
+        try {
+            importConfigDoc = context.getWiki().getDocument(CONFIGURATION_REFERENCE, context);
+            return importConfigDoc.getXObject(CONFIGURATION_CLASS_REFERENCE);
+        } catch (XWikiException e) {
+            logger.warn("Failed to get the LDAP Import configuration document [{}].", CONFIGURATION_REFERENCE, e);
+        }
+
+        return null;
+    }
+}

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
@@ -814,21 +814,8 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         String ldapGroupDN = resultEntry.getDN();
         group.put("dn", ldapGroupDN);
         boolean isAssociated = false;
-        if (StringUtils.isNotBlank(xWikiGroupName)) {
-            if (groupMappings.get(xWikiGroupName) != null && groupMappings.get(xWikiGroupName).contains(ldapGroupDN)) {
-                isAssociated = true;
-            }
-        } else {
-            // In the case where no xWikiGroupName is provided, look through the existing mappings to check if one of
-            // them contains the current DN
-            for (Map.Entry<String, Set<String>> mapping : groupMappings.entrySet()) {
-                if (mapping.getValue().contains(ldapGroupDN)) {
-                    isAssociated = true;
-                    // Due to limitations to the return format of #getLDAPGroupDetails,
-                    // we currently cannot return more than one group mapping.
-                    group.put("xwikiGroup", mapping.getKey());
-                }
-            }
+        if (groupMappings.get(xWikiGroupName) != null && groupMappings.get(xWikiGroupName).contains(ldapGroupDN)) {
+            isAssociated = true;
         }
 
         group.put("isAssociated", Boolean.toString(isAssociated));

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPConfigProvider.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPConfigProvider.java
@@ -39,7 +39,7 @@ import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
  * {@link LDAPUserImportConfiguration}.
  *
  * @version $Id$
- * @since 1.3
+ * @since 1.4
  */
 @Component
 @Singleton

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPConfigProvider.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPConfigProvider.java
@@ -1,0 +1,108 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.ldapuserimport.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.contrib.ldap.XWikiLDAPConfig;
+
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
+
+/**
+ * Provider for the {@link XWikiLDAPConfig}, which will set defaults coming from the
+ * {@link LDAPUserImportConfiguration}.
+ *
+ * @version $Id$
+ * @since 1.3
+ */
+@Component
+@Singleton
+public class XWikiLDAPConfigProvider implements Provider<XWikiLDAPConfig>
+{
+    /**
+     * The hint used by the configuration source defined by the Active Directory application.
+     */
+    private static final String ACTIVE_DIRECTORY_HINT = "activedirectory";
+
+    private static final String LDAP_FIELDS_MAPPING = "ldap_fields_mapping";
+
+    private static final String LDAP_USER_PAGE_NAME = "ldap_userPageName";
+
+    private static final String DEFAULT_LDAP_FIELDS_MAPPING = "first_name=givenName,last_name=sn,email=mail";
+
+    @Inject
+    private ConfigurationSource configurationSource;
+
+    @Inject
+    @Named("context")
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @Inject
+    private LDAPUserImportConfiguration ldapUserImportConfiguration;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public XWikiLDAPConfig get()
+    {
+        XWikiLDAPConfig configuration = new XWikiLDAPConfig(null, getConfigurationSource());
+        setPageNameFormatter(configuration);
+        setFieldMapping(configuration);
+        return configuration;
+    }
+
+    private ConfigurationSource getConfigurationSource()
+    {
+        if (componentManagerProvider.get().hasComponent(ConfigurationSource.class, ACTIVE_DIRECTORY_HINT)) {
+            try {
+                return componentManagerProvider.get().getInstance(ConfigurationSource.class, ACTIVE_DIRECTORY_HINT);
+            } catch (ComponentLookupException e) {
+                logger.error("Failed to get [{}] configuration source. Using the default LDAP configuration source",
+                    ACTIVE_DIRECTORY_HINT, e);
+            }
+        }
+        return configurationSource;
+    }
+
+    private void setPageNameFormatter(XWikiLDAPConfig configuration)
+    {
+        String pageNameFormatter = ldapUserImportConfiguration.getUserPageNameFormatter();
+        if (StringUtils.isNoneBlank(pageNameFormatter)) {
+            configuration.setFinalProperty(LDAP_USER_PAGE_NAME, pageNameFormatter);
+        }
+    }
+
+    private void setFieldMapping(XWikiLDAPConfig configuration)
+    {
+        if (StringUtils.isBlank(configuration.getLDAPParam(LDAP_FIELDS_MAPPING, null))) {
+            configuration.setFinalProperty(LDAP_FIELDS_MAPPING, DEFAULT_LDAP_FIELDS_MAPPING);
+        }
+    }
+}

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
@@ -185,6 +185,7 @@ public class LDAPUserImportScriptService implements ScriptService
 
     /**
      * @return the configuration of the LDAP user importer
+     * @since 1.4
      */
     public LDAPUserImportConfiguration getConfiguration()
     {

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.script.service.ScriptService;
 
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
 import com.xwiki.ldapuserimport.LDAPUserImportManager;
 
 /**
@@ -42,6 +43,9 @@ public class LDAPUserImportScriptService implements ScriptService
 {
     @Inject
     private LDAPUserImportManager manager;
+
+    @Inject
+    private LDAPUserImportConfiguration configuration;
 
     /**
      * Get all the users that have the searched value contained in any of the provided fields value.
@@ -177,5 +181,13 @@ public class LDAPUserImportScriptService implements ScriptService
             return manager.associateGroups(ldapGroupsList, xWikiGroupName);
         }
         return false;
+    }
+
+    /**
+     * @return the configuration of the LDAP user importer
+     */
+    public LDAPUserImportConfiguration getConfiguration()
+    {
+        return configuration;
     }
 }

--- a/application-ldapuserimport-api/src/main/resources/META-INF/components.txt
+++ b/application-ldapuserimport-api/src/main/resources/META-INF/components.txt
@@ -1,2 +1,4 @@
 com.xwiki.ldapuserimport.script.LDAPUserImportScriptService
+com.xwiki.ldapuserimport.internal.DefaultLDAPUserImportConfiguration
 com.xwiki.ldapuserimport.internal.DefaultLDAPUserImportManager
+com.xwiki.ldapuserimport.internal.XWikiLDAPConfigProvider

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
@@ -1221,15 +1221,8 @@ ul#importedUsersList {
   #if ($doc.getObjects('XWiki.XWikiGroups').size() &gt; 0)
     #set ($groupReference = $doc.documentReference)
   #end
-  #set ($configDoc = $xwiki.getDocument('LDAPUserImport.WebHome'))
-  #set ($configObj = $configDoc.getObject('LDAPUserImport.LDAPUserImportConfigClass'))
-  #set ($allFields = $configObj.getValue('ldapUserAttributes'))
-  #set ($resultsNumber = $configObj.getValue('resultsNumber'))
-  ## There is a default number expected also in Java, even if the user will clean this property in the configuration.
-  ## This assignment is purely for display purposes.
-  #if ("$!resultsNumber" == '')
-    #set ($resultsNumber = 20)
-  #end
+  #set ($allFields = $services.ldapuserimport.configuration.getLDAPUserAttributes())
+  #set ($resultsNumber = $services.ldapuserimport.configuration.getMaxUserImportWizardResults())
   #set ($configURL = $xwiki.getURL('XWiki.XWikiPreferences', 'admin', 'editor=globaladmin&amp;section=ldapuserimport'))
   &lt;div class="modal" id="importUsersModal" tabindex="-1" role="dialog"
       aria-labelledby="importUsersModal-label" data-backdrop="static" data-keyboard="false"&gt;
@@ -1251,7 +1244,7 @@ ul#importedUsersList {
               &lt;input type="hidden" name="action" value="searchUsers"/&gt;
             &lt;/div&gt;
             &lt;dl&gt;
-              #if ($configObj.getValue('enableSingleFieldSearch') == 1 &amp;&amp; "$!allFields" != '')
+              #if ($services.ldapuserimport.configuration.getEnableSingleFieldSearch() &amp;&amp; "$!allFields" != '')
                 &lt;dt&gt;
                   &lt;label for="singleField"&gt;
                     $services.localization.render('importUsers.modal.field.label')
@@ -1260,13 +1253,13 @@ ul#importedUsersList {
                 &lt;dd&gt;
                   &lt;select class="xwiki-selectize" id="singleField" name="singleField"&gt;
                     &lt;option value=""&gt;$services.localization.render('importUsers.modal.field.label')&lt;/option&gt;
-                    #foreach ($attr in $allFields.split(','))
+                    #foreach ($attr in $allFields)
                       &lt;option value="$attr"&gt;$attr&lt;/option&gt;
                     #end
                   &lt;/select&gt;
                 &lt;/dd&gt;
               #end
-              &lt;input type="hidden" id="allFields" value="$allFields"/&gt;
+              &lt;input type="hidden" id="allFields" value="$escapetool.xml($stringtool.join($allFields, ','))"/&gt;
               &lt;dt&gt;
                 &lt;label for="searchInput"&gt;
                   $services.localization.render('importUsers.modal.fieldValue.label')


### PR DESCRIPTION
* Introduce the LDAPUserImportConfiguration role
* Provide a default implementation of the LDAPUserImportConfiguration based on the configuration object located in xwiki:LDAPUserImport.WebHome
* Refactor the default LDAPUserImportManager to use this configuration API
* Refactor the LDAPUserImportUIX to use this API
* Update the wrapping of the XWikiLDAPConfig to use the LDAPUserImportConfiguration