### PR TITLE
#63 : Provide a configuration API

### DIFF
--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -71,7 +71,7 @@ public interface LDAPUserImportConfiguration
 
     /**
      * @return the OIDC issuer to be provided when an OIDC Object should be added to new user profiles upon import
-     * @see {{@link #getAddOIDCObject()}}
+     * @see #getAddOIDCObject()
      */
     String getOIDCIssuer();
 

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -22,6 +22,7 @@ package com.xwiki.ldapuserimport;
 import java.util.List;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Configuration for the LDAP User Import application.
@@ -30,6 +31,7 @@ import org.xwiki.component.annotation.Role;
  * @since 1.4
  */
 @Role
+@Unstable
 public interface LDAPUserImportConfiguration
 {
     /**

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -65,7 +65,7 @@ public interface LDAPUserImportConfiguration
 
     /**
      * @return true if a OIDC Object should be added to new user profiles upon import
-     * @see {{@link #getOIDCIssuer()}}
+     * @see #getOIDCIssuer()
      */
     boolean getAddOIDCObject();
 

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.ldapuserimport;
+
+import java.util.List;
+
+import org.xwiki.component.annotation.Role;
+
+/**
+ * Configuration for the LDAP User Import application.
+ *
+ * @version $Id$
+ * @since 1.4
+ */
+@Role
+public interface LDAPUserImportConfiguration
+{
+    /**
+     * Define who is allowed to import LDAP users in the wiki.
+     */
+    enum UserImportPolicy
+    {
+        /**
+         * Only allow global administrators.
+         */
+        GLOBAL_ADMINS,
+
+        /**
+         * Allow both global and local wiki administrators to import users.
+         */
+        GLOBAL_AND_LOCAL_ADMINS,
+
+        /**
+         * Allow anyone able to edit a group to import users.
+         */
+        GROUP_EDITORS
+    }
+
+    /**
+     * @return the list of LDAP user attributes
+     */
+    List<String> getLDAPUserAttributes();
+
+    /**
+     * @return true if user search should be perfromed on a single LDAP field in the UI
+     */
+    boolean getEnableSingleFieldSearch();
+
+    /**
+     * @return true if a OIDC Object should be added to new user profiles upon import
+     * @see {{@link #getOIDCIssuer()}}
+     */
+    boolean getAddOIDCObject();
+
+    /**
+     * @return the OIDC issuer to be provided when an OIDC Object should be added to new user profiles upon import
+     * @see {{@link #getAddOIDCObject()}}
+     */
+    String getOIDCIssuer();
+
+    /**
+     * @return the user import policy
+     */
+    UserImportPolicy getUserImportPolicy();
+
+    /**
+     * @return the format to be used for new user page names.
+     */
+    String getUserPageNameFormatter();
+
+    /**
+     * @return the maximum number of users to be displayed in the import wizard
+     */
+    int getMaxUserImportWizardResults();
+
+    /**
+     * @return true if groups should be updated on synchronization
+     */
+    boolean getTriggerGroupUpdate();
+
+    /**
+     * @return true if user group membership should be updated upon synchronization
+     */
+    boolean getForceUserGroupMembershipUpdate();
+}

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -59,7 +59,7 @@ public interface LDAPUserImportConfiguration
     List<String> getLDAPUserAttributes();
 
     /**
-     * @return true if user search should be perfromed on a single LDAP field in the UI
+     * @return {@code true} if the user search should be performed on a single LDAP field in the UI
      */
     boolean getEnableSingleFieldSearch();
 

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportConfiguration.java
@@ -81,7 +81,7 @@ public interface LDAPUserImportConfiguration
     UserImportPolicy getUserImportPolicy();
 
     /**
-     * @return the format to be used for new user page names.
+     * @return the format to be used for new user page names
      */
     String getUserPageNameFormatter();
 

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
@@ -30,8 +30,10 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -47,23 +49,32 @@ import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
  */
 @Component
 @Singleton
-public class DefaultLDAPUserImportConfiguration implements LDAPUserImportConfiguration
+public class DefaultLDAPUserImportConfiguration implements LDAPUserImportConfiguration, Initializable
 {
     private static final String LDAP_USER_IMPORT = "LDAPUserImport";
-
-    private static final DocumentReference CONFIGURATION_REFERENCE =
-        new DocumentReference("xwiki", LDAP_USER_IMPORT, "WebHome");
 
     private static final LocalDocumentReference CONFIGURATION_CLASS_REFERENCE =
         new LocalDocumentReference(LDAP_USER_IMPORT, "LDAPUserImportConfigClass");
 
     private static final int DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS = 20;
 
+    private DocumentReference configurationReference;
+
     @Inject
     private Provider<XWikiContext> contextProvider;
 
     @Inject
     private Logger logger;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @Override
+    public void initialize()
+    {
+        configurationReference =
+            new DocumentReference(wikiDescriptorManager.getMainWikiId(), LDAP_USER_IMPORT, "WebHome");
+    }
 
     @Override
     public List<String> getLDAPUserAttributes()
@@ -146,10 +157,10 @@ public class DefaultLDAPUserImportConfiguration implements LDAPUserImportConfigu
         XWikiContext context = contextProvider.get();
         XWikiDocument importConfigDoc;
         try {
-            importConfigDoc = context.getWiki().getDocument(CONFIGURATION_REFERENCE, context);
+            importConfigDoc = context.getWiki().getDocument(configurationReference, context);
             return importConfigDoc.getXObject(CONFIGURATION_CLASS_REFERENCE);
         } catch (XWikiException e) {
-            logger.warn("Failed to get the LDAP Import configuration document [{}].", CONFIGURATION_REFERENCE, e);
+            logger.warn("Failed to get the LDAP Import configuration document [{}].", configurationReference, e);
         }
 
         return null;

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportConfiguration.java
@@ -1,0 +1,157 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.ldapuserimport.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
+
+/**
+ * Default implementation of the {@link LDAPUserImportConfiguration}.
+ *
+ * @version $Id$
+ * @since 1.4
+ */
+@Component
+@Singleton
+public class DefaultLDAPUserImportConfiguration implements LDAPUserImportConfiguration
+{
+    private static final String LDAP_USER_IMPORT = "LDAPUserImport";
+
+    private static final DocumentReference CONFIGURATION_REFERENCE =
+        new DocumentReference("xwiki", LDAP_USER_IMPORT, "WebHome");
+
+    private static final LocalDocumentReference CONFIGURATION_CLASS_REFERENCE =
+        new LocalDocumentReference(LDAP_USER_IMPORT, "LDAPUserImportConfigClass");
+
+    private static final int DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS = 20;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public List<String> getLDAPUserAttributes()
+    {
+        BaseObject object = getObject();
+        return object != null ? Arrays.asList(object.getStringValue("ldapUserAttributes").split(","))
+            : Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean getEnableSingleFieldSearch()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("enableSingleFieldSearch") == 1;
+    }
+
+    @Override
+    public boolean getAddOIDCObject()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("addOIDCObject") == 1;
+    }
+
+    @Override
+    public String getOIDCIssuer()
+    {
+        BaseObject object = getObject();
+        return (object != null) ? object.getStringValue("OIDCIssuer") : StringUtils.EMPTY;
+    }
+
+    @Override
+    public UserImportPolicy getUserImportPolicy()
+    {
+        BaseObject object = getObject();
+
+        if (object != null) {
+            String value = object.getStringValue("usersAllowedToImport");
+
+            if ("localAdmin".equals(value)) {
+                return UserImportPolicy.GLOBAL_AND_LOCAL_ADMINS;
+            } else if ("groupEditor".equals(value)) {
+                return UserImportPolicy.GROUP_EDITORS;
+            }
+        }
+
+        return UserImportPolicy.GLOBAL_ADMINS;
+    }
+
+    @Override
+    public String getUserPageNameFormatter()
+    {
+        BaseObject object = getObject();
+        return (object != null) ? object.getStringValue("pageNameFormatter") : StringUtils.EMPTY;
+    }
+
+    @Override
+    public int getMaxUserImportWizardResults()
+    {
+        BaseObject object = getObject();
+        return (object != null) ? object.getIntValue("resultsNumber", DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS)
+            : DEFAULT_MAX_USER_IMPORT_WIZARD_RESULTS;
+    }
+
+    @Override
+    public boolean getTriggerGroupUpdate()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("triggerGroupsUpdate") == 1;
+    }
+
+    @Override
+    public boolean getForceUserGroupMembershipUpdate()
+    {
+        BaseObject object = getObject();
+        return object != null && object.getIntValue("forceXWikiUsersGroupMembershipUpdate") == 1;
+    }
+
+    private BaseObject getObject()
+    {
+        XWikiContext context = contextProvider.get();
+        XWikiDocument importConfigDoc;
+        try {
+            importConfigDoc = context.getWiki().getDocument(CONFIGURATION_REFERENCE, context);
+            return importConfigDoc.getXObject(CONFIGURATION_CLASS_REFERENCE);
+        } catch (XWikiException e) {
+            logger.warn("Failed to get the LDAP Import configuration document [{}].", CONFIGURATION_REFERENCE, e);
+        }
+
+        return null;
+    }
+}

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPUserImportManager.java
@@ -40,7 +40,6 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.contrib.ldap.PagedLDAPSearchResults;
@@ -62,6 +61,7 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
 import com.xwiki.ldapuserimport.LDAPUserImportManager;
 
 /**
@@ -101,8 +101,6 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
 
     private static final String MAIN_WIKI_NAME = "xwiki";
 
-    private static final String LDAP_USER_IMPORT = "LDAPUserImport";
-
     private static final String FIELDS_SEPARATOR = ",";
 
     private static final String XWIKI = "XWiki";
@@ -127,15 +125,6 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
     private static final LocalDocumentReference GROUP_CLASS_REFERENCE =
         new LocalDocumentReference(XWIKI, "XWikiGroups");
 
-    private static final LocalDocumentReference CONFIGURATION_REFERENCE =
-        new LocalDocumentReference(LDAP_USER_IMPORT, "WebHome");
-
-    private static final LocalDocumentReference CONFIGURATION_CLASS_REFERENCE =
-        new LocalDocumentReference(LDAP_USER_IMPORT, "LDAPUserImportConfigClass");
-
-    @Inject
-    private ConfigurationSource configurationSource;
-
     @Inject
     @Named("context")
     private Provider<ComponentManager> componentManagerProvider;
@@ -152,6 +141,12 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
     @Inject
     private Provider<XWikiContext> contextProvider;
 
+    @Inject
+    private Provider<XWikiLDAPConfig> xwikiLDAPConfigProvider;
+
+    @Inject
+    private LDAPUserImportConfiguration ldapUserImportConfiguration;
+
     /**
      * Get all the users that have the searched value contained in any of the provided fields value.
      */
@@ -164,7 +159,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         // Make sure to use the main wiki configuration source.
         context.setWikiId(context.getMainXWiki());
 
-        XWikiLDAPConfig configuration = getConfiguration();
+        XWikiLDAPConfig configuration = xwikiLDAPConfigProvider.get();
         XWikiLDAPConnection connection = new XWikiLDAPConnection(configuration);
         String loginDN = configuration.getLDAPBindDN();
         String password = configuration.getLDAPBindPassword();
@@ -203,16 +198,6 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
             context.setWikiId(currentWikiId);
         }
         return Collections.emptyMap();
-    }
-
-    private XWikiLDAPConfig getConfiguration() throws Exception
-    {
-        XWikiLDAPConfig configuration = new XWikiLDAPConfig(null, getConfigurationSource());
-        setPageNameFormatter(configuration);
-        if (StringUtils.isBlank(configuration.getLDAPParam(LDAP_FIELDS_MAPPING, null))) {
-            configuration.setFinalProperty(LDAP_FIELDS_MAPPING, DEFAULT_LDAP_FIELDS_MAPPING);
-        }
-        return configuration;
     }
 
     private Map<String, String> getFieldsMap(XWikiLDAPConfig configuration)
@@ -310,7 +295,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
             resultEntry = result.next();
             if (resultEntry != null) {
                 Map<String, String> fieldsMap = getFieldsMap(configuration);
-                int maxDisplayedUsersNb = getMaxDisplayedUsersNb();
+                int maxDisplayedUsersNb = ldapUserImportConfiguration.getMaxUserImportWizardResults();
                 boolean hasMore;
                 Map<String, Map<String, String>> usersMap = new HashMap<>();
                 do {
@@ -348,19 +333,6 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
             throw e;
         }
         return Collections.emptyMap();
-    }
-
-    /**
-     * @return the maximum number of users to be displayed in the import wizard
-     * @throws XWikiException
-     */
-    private int getMaxDisplayedUsersNb() throws Exception
-    {
-        int resultsNumber = getLDAPImportConfiguration().getIntValue("resultsNumber");
-        if (resultsNumber == 0) {
-            resultsNumber = 20;
-        }
-        return resultsNumber;
     }
 
     private Map<String, String> getUserDetails(XWikiLDAPConnection connection, Map<String, String> fieldsMap,
@@ -419,7 +391,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
             // Make sure to use the main wiki configuration source.
             context.setWikiId(context.getMainXWiki());
 
-            XWikiLDAPConfig configuration = getConfiguration();
+            XWikiLDAPConfig configuration = xwikiLDAPConfigProvider.get();
             XWikiLDAPConnection connection = new XWikiLDAPConnection(configuration);
             XWikiLDAPUtils ldapUtils = new XWikiLDAPUtils(connection, configuration);
             ldapUtils.setUidAttributeName(configuration.getLDAPParam(LDAP_UID_ATTR, CN));
@@ -461,28 +433,6 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         return Collections.emptyMap();
     }
 
-    private void setPageNameFormatter(XWikiLDAPConfig configuration) throws Exception
-    {
-        String pageNameFormatter = getLDAPImportConfiguration().getStringValue("pageNameFormatter");
-        if (StringUtils.isNoneBlank(pageNameFormatter)) {
-            configuration.setFinalProperty("ldap_userPageName", pageNameFormatter);
-        }
-    }
-
-    private BaseObject getLDAPImportConfiguration() throws XWikiException
-    {
-        XWikiContext context = contextProvider.get();
-        XWikiDocument importConfigDoc;
-        try {
-            importConfigDoc = context.getWiki().getDocument(CONFIGURATION_REFERENCE, context);
-            BaseObject importConfigObj = importConfigDoc.getXObject(CONFIGURATION_CLASS_REFERENCE);
-            return importConfigObj;
-        } catch (XWikiException e) {
-            logger.warn("Failed to get LDAP Import configuration document [{}].", CONFIGURATION_REFERENCE, e);
-            throw e;
-        }
-    }
-
     /**
      * This method handles the creation of the XWiki.OIDC.UserClass object in user profile. The subject property should
      * be populated according to a mapping between the LDAP user attribute and OIDC subject format. The default mapping
@@ -496,14 +446,14 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
      */
     private void addOIDCObject(XWikiDocument userDoc, String subject, XWikiContext context) throws Exception
     {
-        boolean addOIDCObj = getLDAPImportConfiguration().getIntValue("addOIDCObject") != 0;
+        boolean addOIDCObj = ldapUserImportConfiguration.getAddOIDCObject();
         boolean oIDCClassExists = context.getWiki().exists(OIDC_CLASS, context);
         if (addOIDCObj && oIDCClassExists) {
             try {
                 BaseObject oIDCObj = userDoc.getXObject(OIDC_CLASS, true, context);
                 BaseObject clonedOIDCObject = oIDCObj.clone();
                 oIDCObj.setStringValue("subject", subject);
-                oIDCObj.setStringValue("issuer", getLDAPImportConfiguration().getStringValue("OIDCIssuer"));
+                oIDCObj.setStringValue("issuer", ldapUserImportConfiguration.getOIDCIssuer());
                 if (!oIDCObj.equals(clonedOIDCObject)) {
                     context.getWiki().saveDocument(userDoc, "OIDC user object added.", context);
                 }
@@ -548,44 +498,27 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
     @Override
     public boolean hasImport() throws Exception
     {
-        String value = getLDAPImportConfiguration().getStringValue("usersAllowedToImport");
         boolean hasImport = false;
 
-        // Check if the current user is global admin.
-        if (value.equals("globalAdmin") || StringUtils.isAllEmpty(value)) {
-            hasImport = contextualAuthorizationManager.hasAccess(Right.ADMIN, GLOBAL_PREFERENCES);
+        switch (ldapUserImportConfiguration.getUserImportPolicy()) {
+            case GLOBAL_AND_LOCAL_ADMINS:
+                hasImport = contextualAuthorizationManager.hasAccess(Right.ADMIN);
+                break;
+            case GROUP_EDITORS:
+                hasImport = contextualAuthorizationManager.hasAccess(Right.EDIT);
+                break;
+            default:
+                hasImport = contextualAuthorizationManager.hasAccess(Right.ADMIN, GLOBAL_PREFERENCES);
+                break;
         }
 
-        // Check if the current user is local admin.
-        if (!hasImport && value.equals("localAdmin")) {
-            hasImport = contextualAuthorizationManager.hasAccess(Right.ADMIN);
-        }
-
-        // Check if the current user has edit right on the current group.
-        if (!hasImport && value.equals("groupEditor")) {
-            hasImport = contextualAuthorizationManager.hasAccess(Right.EDIT);
-        }
         return hasImport;
-    }
-
-    private ConfigurationSource getConfigurationSource() throws Exception
-    {
-        if (componentManagerProvider.get().hasComponent(ConfigurationSource.class, ACTIVE_DIRECTORY_HINT)) {
-            try {
-                return componentManagerProvider.get().getInstance(ConfigurationSource.class, ACTIVE_DIRECTORY_HINT);
-            } catch (ComponentLookupException e) {
-                logger.error("Failed to get [{}] configuration source. Using the default LDAP configuration source",
-                    ACTIVE_DIRECTORY_HINT, e);
-                throw e;
-            }
-        }
-        return configurationSource;
     }
 
     @Override
     public boolean displayedMax(int displayedUsersNb) throws Exception
     {
-        return getMaxDisplayedUsersNb() == displayedUsersNb;
+        return ldapUserImportConfiguration.getMaxUserImportWizardResults() == displayedUsersNb;
     }
 
     @Override
@@ -596,7 +529,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         // Make sure to use the main wiki configuration source.
         context.setWikiId(context.getMainXWiki());
         List<String> groups = new ArrayList<>();
-        for (String groupName : getConfiguration().getGroupMappings().keySet()) {
+        for (String groupName : xwikiLDAPConfigProvider.get().getGroupMappings().keySet()) {
             groups.add(groupName);
         }
         context.setWikiId(currentWikiId);
@@ -616,7 +549,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         // Make sure to use the main wiki configuration source.
         context.setWikiId(context.getMainXWiki());
 
-        XWikiLDAPConfig configuration = getConfiguration();
+        XWikiLDAPConfig configuration = xwikiLDAPConfigProvider.get();
         XWikiLDAPConnection connection = new XWikiLDAPConnection(configuration);
         try {
             connection.open(configuration.getLDAPBindDN(), configuration.getLDAPBindPassword(), context);
@@ -644,7 +577,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         // Make sure to use the main wiki configuration source.
         context.setWikiId(context.getMainXWiki());
 
-        XWikiLDAPConfig configuration = getConfiguration();
+        XWikiLDAPConfig configuration = xwikiLDAPConfigProvider.get();
         XWikiLDAPConnection connection = new XWikiLDAPConnection(configuration);
         XWikiLDAPUtils ldapUtils = new XWikiLDAPUtils(connection, configuration);
         String uidAttributeName = configuration.getLDAPParam(LDAP_UID_ATTR, CN);
@@ -713,7 +646,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
 
         try {
             // Add all the XWiki users that are not LDAP users to be also synchronized(removed) in the current group.
-            if (getLDAPImportConfiguration().getIntValue("forceXWikiUsersGroupMembershipUpdate") != 0) {
+            if (ldapUserImportConfiguration.getForceUserGroupMembershipUpdate()) {
                 DocumentReference xwikiGroupReference = documentReferenceResolver.resolve(xWikiGroupName);
                 XWikiDocument groupDoc = context.getWiki().getDocument(xwikiGroupReference, context);
                 List<BaseObject> xobjects =
@@ -777,8 +710,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
     @Override
     public void updateGroups() throws Exception
     {
-        boolean triggerGroupsUpdate = getLDAPImportConfiguration().getIntValue("triggerGroupsUpdate") != 0;
-        if (triggerGroupsUpdate) {
+        if (ldapUserImportConfiguration.getTriggerGroupUpdate()) {
             for (String xWikiGroupName : getXWikiMappedGroups()) {
                 updateGroup(xWikiGroupName);
             }
@@ -793,7 +725,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         // Make sure to use the main wiki configuration source.
         context.setWikiId(context.getMainXWiki());
 
-        XWikiLDAPConfig configuration = getConfiguration();
+        XWikiLDAPConfig configuration = xwikiLDAPConfigProvider.get();
         XWikiLDAPConnection connection = new XWikiLDAPConnection(configuration);
 
         Map<String, Map<String, String>> ldapGroups = new HashMap<>();
@@ -837,7 +769,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
         try {
             resultEntry = result.next();
             if (resultEntry != null) {
-                int maxDisplayedUsersNb = getMaxDisplayedUsersNb();
+                int maxDisplayedUsersNb = ldapUserImportConfiguration.getMaxUserImportWizardResults();
                 boolean hasMore;
                 Map<String, Map<String, String>> groupsMap = new HashMap<>();
                 Map<String, Set<String>> ldapGroupMapping = configuration.getGroupMappings();
@@ -910,7 +842,7 @@ public class DefaultLDAPUserImportManager implements LDAPUserImportManager
                 XWikiDocument configSourceDoc = context.getWiki().getDocument(configSourceDocRef, context);
 
                 Set<String> ldapGroupsSetToAdd = new HashSet<String>(Arrays.asList(ldapGroupsArray));
-                Map<String, Set<String>> groupMapping = getConfiguration().getGroupMappings();
+                Map<String, Set<String>> groupMapping = xwikiLDAPConfigProvider.get().getGroupMappings();
                 for (Entry<String, Set<String>> entry : groupMapping.entrySet()) {
                     Set<String> modifiedSet =
                         entry.getValue().stream().map((value) -> StringUtils.replace(value, "\\", "\\\\"))

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPConfigProvider.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPConfigProvider.java
@@ -1,0 +1,108 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.ldapuserimport.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.contrib.ldap.XWikiLDAPConfig;
+
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
+
+/**
+ * Provider for the {@link XWikiLDAPConfig}, which will set defaults coming from the
+ * {@link LDAPUserImportConfiguration}.
+ *
+ * @version $Id$
+ * @since 1.4
+ */
+@Component
+@Singleton
+public class XWikiLDAPConfigProvider implements Provider<XWikiLDAPConfig>
+{
+    /**
+     * The hint used by the configuration source defined by the Active Directory application.
+     */
+    private static final String ACTIVE_DIRECTORY_HINT = "activedirectory";
+
+    private static final String LDAP_FIELDS_MAPPING = "ldap_fields_mapping";
+
+    private static final String LDAP_USER_PAGE_NAME = "ldap_userPageName";
+
+    private static final String DEFAULT_LDAP_FIELDS_MAPPING = "first_name=givenName,last_name=sn,email=mail";
+
+    @Inject
+    private ConfigurationSource configurationSource;
+
+    @Inject
+    @Named("context")
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @Inject
+    private LDAPUserImportConfiguration ldapUserImportConfiguration;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public XWikiLDAPConfig get()
+    {
+        XWikiLDAPConfig configuration = new XWikiLDAPConfig(null, getConfigurationSource());
+        setPageNameFormatter(configuration);
+        setFieldMapping(configuration);
+        return configuration;
+    }
+
+    private ConfigurationSource getConfigurationSource()
+    {
+        if (componentManagerProvider.get().hasComponent(ConfigurationSource.class, ACTIVE_DIRECTORY_HINT)) {
+            try {
+                return componentManagerProvider.get().getInstance(ConfigurationSource.class, ACTIVE_DIRECTORY_HINT);
+            } catch (ComponentLookupException e) {
+                logger.error("Failed to get [{}] configuration source. Using the default LDAP configuration source",
+                    ACTIVE_DIRECTORY_HINT, e);
+            }
+        }
+        return configurationSource;
+    }
+
+    private void setPageNameFormatter(XWikiLDAPConfig configuration)
+    {
+        String pageNameFormatter = ldapUserImportConfiguration.getUserPageNameFormatter();
+        if (StringUtils.isNoneBlank(pageNameFormatter)) {
+            configuration.setFinalProperty(LDAP_USER_PAGE_NAME, pageNameFormatter);
+        }
+    }
+
+    private void setFieldMapping(XWikiLDAPConfig configuration)
+    {
+        if (StringUtils.isBlank(configuration.getLDAPParam(LDAP_FIELDS_MAPPING, null))) {
+            configuration.setFinalProperty(LDAP_FIELDS_MAPPING, DEFAULT_LDAP_FIELDS_MAPPING);
+        }
+    }
+}

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
@@ -28,6 +28,7 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.script.service.ScriptService;
+import org.xwiki.stability.Unstable;
 
 import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
 import com.xwiki.ldapuserimport.LDAPUserImportManager;
@@ -187,6 +188,7 @@ public class LDAPUserImportScriptService implements ScriptService
      * @return the configuration of the LDAP user importer
      * @since 1.4
      */
+    @Unstable
     public LDAPUserImportConfiguration getConfiguration()
     {
         return configuration;

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.script.service.ScriptService;
 
+import com.xwiki.ldapuserimport.LDAPUserImportConfiguration;
 import com.xwiki.ldapuserimport.LDAPUserImportManager;
 
 /**
@@ -42,6 +43,9 @@ public class LDAPUserImportScriptService implements ScriptService
 {
     @Inject
     private LDAPUserImportManager manager;
+
+    @Inject
+    private LDAPUserImportConfiguration configuration;
 
     /**
      * Get all the users that have the searched value contained in any of the provided fields value.
@@ -177,5 +181,14 @@ public class LDAPUserImportScriptService implements ScriptService
             return manager.associateGroups(ldapGroupsList, xWikiGroupName);
         }
         return false;
+    }
+
+    /**
+     * @return the configuration of the LDAP user importer
+     * @since 1.4
+     */
+    public LDAPUserImportConfiguration getConfiguration()
+    {
+        return configuration;
     }
 }

--- a/application-ldapuserimport-api/src/main/resources/META-INF/components.txt
+++ b/application-ldapuserimport-api/src/main/resources/META-INF/components.txt
@@ -1,2 +1,4 @@
 com.xwiki.ldapuserimport.script.LDAPUserImportScriptService
+com.xwiki.ldapuserimport.internal.DefaultLDAPUserImportConfiguration
 com.xwiki.ldapuserimport.internal.DefaultLDAPUserImportManager
+com.xwiki.ldapuserimport.internal.XWikiLDAPConfigProvider

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
@@ -1221,15 +1221,8 @@ ul#importedUsersList {
   #if ($doc.getObjects('XWiki.XWikiGroups').size() &gt; 0)
     #set ($groupReference = $doc.documentReference)
   #end
-  #set ($configDoc = $xwiki.getDocument('LDAPUserImport.WebHome'))
-  #set ($configObj = $configDoc.getObject('LDAPUserImport.LDAPUserImportConfigClass'))
-  #set ($allFields = $configObj.getValue('ldapUserAttributes'))
-  #set ($resultsNumber = $configObj.getValue('resultsNumber'))
-  ## There is a default number expected also in Java, even if the user will clean this property in the configuration.
-  ## This assignment is purely for display purposes.
-  #if ("$!resultsNumber" == '')
-    #set ($resultsNumber = 20)
-  #end
+  #set ($allFields = $services.ldapuserimport.configuration.getLDAPUserAttributes())
+  #set ($resultsNumber = $services.ldapuserimport.configuration.getMaxUserImportWizardResults())
   #set ($configURL = $xwiki.getURL('XWiki.XWikiPreferences', 'admin', 'editor=globaladmin&amp;section=ldapuserimport'))
   &lt;div class="modal" id="importUsersModal" tabindex="-1" role="dialog"
       aria-labelledby="importUsersModal-label" data-backdrop="static" data-keyboard="false"&gt;
@@ -1251,7 +1244,7 @@ ul#importedUsersList {
               &lt;input type="hidden" name="action" value="searchUsers"/&gt;
             &lt;/div&gt;
             &lt;dl&gt;
-              #if ($configObj.getValue('enableSingleFieldSearch') == 1 &amp;&amp; "$!allFields" != '')
+              #if ($services.ldapuserimport.configuration.getEnableSingleFieldSearch() &amp;&amp; "$!allFields" != '')
                 &lt;dt&gt;
                   &lt;label for="singleField"&gt;
                     $services.localization.render('importUsers.modal.field.label')
@@ -1260,13 +1253,13 @@ ul#importedUsersList {
                 &lt;dd&gt;
                   &lt;select class="xwiki-selectize" id="singleField" name="singleField"&gt;
                     &lt;option value=""&gt;$services.localization.render('importUsers.modal.field.label')&lt;/option&gt;
-                    #foreach ($attr in $allFields.split(','))
+                    #foreach ($attr in $allFields)
                       &lt;option value="$attr"&gt;$attr&lt;/option&gt;
                     #end
                   &lt;/select&gt;
                 &lt;/dd&gt;
               #end
-              &lt;input type="hidden" id="allFields" value="$allFields"/&gt;
+              &lt;input type="hidden" id="allFields" value="$escapetool.xml($stringtool.join($allFields, ','))"/&gt;
               &lt;dt&gt;
                 &lt;label for="searchInput"&gt;
                   $services.localization.render('importUsers.modal.fieldValue.label')


### PR DESCRIPTION
* Introduce the LDAPUserImportConfiguration role
* Provide a default implementation of the LDAPUserImportConfiguration based on the configuration object located in xwiki:LDAPUserImport.WebHome
* Refactor the default LDAPUserImportManager to use this configuration API
* Refactor the LDAPUserImportUIX to use this API
* Update the wrapping of the XWikiLDAPConfig to use the LDAPUserImportConfiguration