### PR TITLE
#75 Performance Improvements fixes by allowing default search to be "begin with search"

### DIFF
--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportManager.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/LDAPUserImportManager.java
@@ -36,10 +36,12 @@ public interface LDAPUserImportManager
      * @param singleField the field to only filter when the single field search is enabled
      * @param allFields the list of all configured fields
      * @param searchInput the value to search for
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
      * @return a map containing all the matching users with information from all fields
      * @throws Exception in case of exceptions
      */
-    Map<String, Map<String, String>> getUsers(String singleField, String allFields, String searchInput)
+    Map<String, Map<String, String>> getUsers(String singleField, String allFields,
+        String searchInput, boolean isFullSearch)
         throws Exception;
 
     /**
@@ -110,9 +112,11 @@ public interface LDAPUserImportManager
      * @param searchInput the value to search for
      * @param xWikiGroupName the group name
      * @return the list of groups
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
      * @throws Exception in case of exceptions
      */
-    Map<String, Map<String, String>> getLDAPGroups(String searchInput, String xWikiGroupName) throws Exception;
+    Map<String, Map<String, String>> getLDAPGroups(String searchInput, String xWikiGroupName,
+                                                   boolean isFullSearch) throws Exception;
 
     /**
      * Associate a list of LDAP groups to an XWiki group.

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPGroupImportManager.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/DefaultLDAPGroupImportManager.java
@@ -126,7 +126,7 @@ public class DefaultLDAPGroupImportManager implements LDAPGroupImportManager
     public Job importLDAPGroups() throws JobException
     {
         String groupSearchFilter = StringUtils.isBlank(ldapUserImportConfiguration.getLDAPGroupImportSearchFilter())
-            ? getGroupsFilter(StringUtils.EMPTY, xWikiLDAPConfigProvider.get())
+            ? getGroupsFilter(StringUtils.EMPTY, xWikiLDAPConfigProvider.get(), false)
             : ldapUserImportConfiguration.getLDAPGroupImportSearchFilter();
         return importLDAPGroups(ldapUserImportConfiguration.getGroupPageNameFormat(),
             ldapUserImportConfiguration.getLDAPGroupImportSearchDN(), groupSearchFilter,

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPUtilsHelper.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPUtilsHelper.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import org.xwiki.contrib.ldap.XWikiLDAPConfig;
 import org.xwiki.contrib.ldap.XWikiLDAPConnection;
 import org.xwiki.contrib.ldap.XWikiLDAPUtils;
-import org.xwiki.text.StringUtils;
 
 /**
  * Internal utility class to provide help methods to deal with LDAP queries.
@@ -54,12 +53,24 @@ public final class XWikiLDAPUtilsHelper
      */
     public static final String LDAP_BASE_DN = "ldap_base_DN";
 
-    private static final String FILTER_CLOSING_MARK = "))";
+    private static final String OR_FILTER_STARTING_MARK = "(|";
+
+    private static final String AND_FILTER_STARTING_MARK = "(&";
+
+    private static final String FILTER_ENDING_MARK = ")";
 
     private static final String LDAP_GROUP_CLASSES_KEY = "ldap_group_classes";
 
+    private static final String LDAP_GROUP_SEARCH_FIELDS_KEY = "ldap_group_searchfields";
+
+    private static final String LDAP_USER_CLASSES_KEY = "ldap_user_classes";
+
     private static final String LDAP_GROUP_CLASSES = "group,groupOfNames,groupOfUniqueNames,dynamicGroup,"
         + "dynamicGroupAux,groupWiseDistributionList,posixGroup,apple-group";
+
+    private static final String LDAP_GROUP_SEARCH_FIELDS = CN;
+
+    private static final String LDAP_USER_CLASSES = "inetOrgPerson";
 
     private XWikiLDAPUtilsHelper()
     {
@@ -67,59 +78,107 @@ public final class XWikiLDAPUtilsHelper
     }
 
     /**
-     * Filter pattern: (&({0}={1})(|({2}=*{3}*)({4}=*{5}*)({6}=*{7}*)...)).
+     * Method to retrieve the Users Filter to search for users in LDAP.
+     * Filter pattern for contains search:
+     * (&(|(objectClass={1A})(objectClass={1B}))(|({2}=*{3}*)({4}=*{5}*)({6}=*{7}*)...)).
+     * Filter pattern for begins with search:
+     * (&(|(objectClass={1A})(objectClass={1B}))(|({2}={3}*)({4}={5}*)({6}={7}*)...)).
      *
      * @param searchInput the value to search for
      * @param searchFields a comma-separated list of fields to search for
-     * @return the filter
-     */
-    public static String getUsersFilter(String searchInput, String searchFields)
-    {
-        return getUsersFilter(searchInput, searchFields.split(XWikiLDAPConfig.DEFAULT_SEPARATOR));
-    }
-
-    /**
-     * Filter pattern: (&({0}={1})(|({2}=*{3}*)({4}=*{5}*)({6}=*{7}*)...)).
-     *
-     * @param searchInput the value to search for
-     * @param searchFields the list of fields to search for
-     * @return the filter
-     */
-    public static String getUsersFilter(String searchInput, String[] searchFields)
-    {
-        StringBuilder filter = new StringBuilder("(&(objectClass=*)(|");
-        for (String field : searchFields) {
-            filter.append(String.format("(%s=*%s*)",
-                XWikiLDAPConnection.escapeLDAPSearchFilter(field),
-                XWikiLDAPConnection.escapeLDAPSearchFilter(searchInput)));
-        }
-        filter.append(FILTER_CLOSING_MARK);
-        return filter.toString();
-    }
-
-    /**
-     * Filter pattern: (&(cn=*{0}*)(|(objectClass=class1)(objectClass=class2)...(objectClass=classN))).
-     *
-     * @param searchInput the input to search for
      * @param configuration the current LDAP configuration
-     * @return the group filter according to the pattern
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
+     * @return the filter
      */
-    public static String getGroupsFilter(String searchInput, XWikiLDAPConfig configuration)
+    public static String getUsersFilter(String searchInput, String searchFields,
+                                        XWikiLDAPConfig configuration, boolean isFullSearch)
     {
-        String[] objectClasses = configuration.getLDAPParam(LDAP_GROUP_CLASSES_KEY, LDAP_GROUP_CLASSES)
-            .split(XWikiLDAPConfig.DEFAULT_SEPARATOR);
+        return getUsersFilter(searchInput, searchFields.split(XWikiLDAPConfig.DEFAULT_SEPARATOR),
+                              configuration, isFullSearch);
+    }
 
-        StringBuilder filter = new StringBuilder("(&");
-        if (StringUtils.isNotBlank(searchInput)) {
-            filter.append(String.format("(cn=*%s*)", XWikiLDAPConnection.escapeLDAPSearchFilter(searchInput)));
-        }
-        filter.append("(|");
+    /**
+     * Method to retrieve a Filter for objectClasses.
+     *
+     * @param objectClassesString A comma separated list of LDAP objectClasses
+     * @return the filter
+     **/
+    public static String getFilterFromObjectClasses(String objectClassesString)
+    {
+        String[] objectClasses = objectClassesString.split(XWikiLDAPConfig.DEFAULT_SEPARATOR);
 
+        StringBuilder filter = new StringBuilder();
+        filter.append(OR_FILTER_STARTING_MARK);
         for (String objectClass : objectClasses) {
             filter.append(String.format("(objectClass=%s)", objectClass));
         }
-        filter.append(FILTER_CLOSING_MARK);
+        filter.append(FILTER_ENDING_MARK);
         return filter.toString();
+    }
+
+    /**
+     * Method to retrieve the Search Filter to search for users or groups in LDAP.
+     *
+     * @param objectClassesString A comma separated list of LDAP objectClasses
+     * @param searchInput the value to search for
+     * @param searchFields a comma-separated list of fields to search for
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
+     * @return the filter
+     **/
+    public static String getSearchFilter(String objectClassesString, String searchInput, String[] searchFields,
+                                         boolean isFullSearch)
+    {
+        String filterFormat = "(%s=%s*)";
+        if (isFullSearch) {
+            filterFormat = "(%s=*%s*)";
+        }
+
+        String objectClassesFilter = getFilterFromObjectClasses(objectClassesString);
+        StringBuilder filter = new StringBuilder(AND_FILTER_STARTING_MARK);
+
+        filter.append(OR_FILTER_STARTING_MARK);
+        for (String field : searchFields) {
+            filter.append(String.format(filterFormat,
+                XWikiLDAPConnection.escapeLDAPSearchFilter(field),
+                XWikiLDAPConnection.escapeLDAPSearchFilter(searchInput)));
+        }
+        filter.append(FILTER_ENDING_MARK);
+
+        filter.append(objectClassesFilter);
+        filter.append(FILTER_ENDING_MARK);
+        return filter.toString();
+    }
+
+    /**
+     * Method to get the filter to search for users in LDAP.
+     *
+     * @param searchInput the value to search for
+     * @param searchFields the list of fields to search for
+     * @param configuration the current LDAP configuration
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
+     * @return the filter
+     */
+    public static String getUsersFilter(String searchInput, String[] searchFields,
+                                        XWikiLDAPConfig configuration, boolean isFullSearch)
+    {
+        String objectClassesString = configuration.getLDAPParam(LDAP_USER_CLASSES_KEY, LDAP_USER_CLASSES);
+        return getSearchFilter(objectClassesString, searchInput, searchFields, isFullSearch);
+    }
+
+    /**
+     * Method to get the filter to search for groups in LDAP.
+     *
+     * @param searchInput the input to search for
+     * @param configuration the current LDAP configuration
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
+     * @return the group filter according to the pattern
+     */
+    public static String getGroupsFilter(String searchInput, XWikiLDAPConfig configuration, boolean isFullSearch)
+    {
+        String objectClassesString = configuration.getLDAPParam(LDAP_GROUP_CLASSES_KEY, LDAP_GROUP_CLASSES);
+        String searchFields = configuration.getLDAPParam(LDAP_GROUP_SEARCH_FIELDS_KEY, LDAP_GROUP_SEARCH_FIELDS);
+        return getSearchFilter(objectClassesString, searchInput,
+                               searchFields.split(XWikiLDAPConfig.DEFAULT_SEPARATOR), isFullSearch);
     }
 
     /**

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPUtilsHelper.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/internal/XWikiLDAPUtilsHelper.java
@@ -70,7 +70,7 @@ public final class XWikiLDAPUtilsHelper
 
     private static final String LDAP_GROUP_SEARCH_FIELDS = CN;
 
-    private static final String LDAP_USER_CLASSES = "inetOrgPerson";
+    private static final String LDAP_USER_CLASSES = "*";
 
     private XWikiLDAPUtilsHelper()
     {

--- a/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
+++ b/application-ldapuserimport-api/src/main/java/com/xwiki/ldapuserimport/script/LDAPUserImportScriptService.java
@@ -64,14 +64,16 @@ public class LDAPUserImportScriptService implements ScriptService
      * @param singleField the field to only filter when the single field search is enabled
      * @param allFields the list of all configured fields
      * @param searchInput the value to search for
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
      * @return a map containing all the matching users with information from all fields
      * @throws Exception in case of exceptions
      */
-    public Map<String, Map<String, String>> getUsers(String singleField, String allFields, String searchInput)
+    public Map<String, Map<String, String>> getUsers(String singleField, String allFields,
+                                                     String searchInput, boolean isFullSearch)
         throws Exception
     {
         if (hasImport()) {
-            return userImportManager.getUsers(singleField, allFields, searchInput);
+            return userImportManager.getUsers(singleField, allFields, searchInput, isFullSearch);
         }
         return Collections.emptyMap();
     }
@@ -170,12 +172,14 @@ public class LDAPUserImportScriptService implements ScriptService
      *
      * @param searchInput the value to search for
      * @param xWikiGroupName the group name
+     * @param isFullSearch allowing to choose if the search is a "contains" search or a "begin with" search
      * @return the list of groups
      * @throws Exception in case of exceptions
      */
-    public Map<String, Map<String, String>> getLDAPGroups(String searchInput, String xWikiGroupName) throws Exception
+    public Map<String, Map<String, String>> getLDAPGroups(String searchInput,
+           String xWikiGroupName, boolean isFullSearch) throws Exception
     {
-        return userImportManager.getLDAPGroups(searchInput, xWikiGroupName);
+        return userImportManager.getLDAPGroups(searchInput, xWikiGroupName, isFullSearch);
     }
 
     /**

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportService.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportService.xml
@@ -76,7 +76,11 @@
         $jsontool.serialize({'message': $message})
       #elseif ($request.action == 'getLDAPGroups')
         #set ($noResultsMessage = $services.localization.render('importUsers.associateGroups.modal.fieldValue.noResults'))
-        #set ($groups = $services.ldapuserimport.getLDAPGroups($request.searchInput, $request.xWikiGroupName))
+        #set ($isFullSearch = false)
+        #if ($request.searchType=="1")
+          #set ($isFullSearch = true)
+        #end
+        #set ($groups = $services.ldapuserimport.getLDAPGroups($request.searchInput, $request.xWikiGroupName, $isFullSearch))
         #foreach ($group in $groups.entrySet())
           #if ($group.value.isAssociated == true)
             #set ($message = $services.localization.render('importUsers.associateGroups.modal.alreadyAssociated', [$group.value.description, $group.value.cn]))
@@ -99,7 +103,11 @@
         #end
         $jsontool.serialize({'message': $message, 'status': $status})
       #elseif ($request.action == 'searchUsers')
-        #set ($users = $services.ldapuserimport.getUsers($request.singleField, $request.allFields, $request.searchInput))
+        #set ($isFullSearch = false)
+        #if ($request.searchType=="1")
+          #set ($isFullSearch = true)
+        #end
+        #set ($users = $services.ldapuserimport.getUsers($request.singleField, $request.allFields, $request.searchInput, $isFullSearch))
         #set ($noResultsMessage = $services.localization.render('importUsers.modal.fieldValue.noResults'))
         #foreach ($user in $users.entrySet())
           #set ($params = [])

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportTranslations.fr.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportTranslations.fr.xml
@@ -47,6 +47,7 @@ importUsers.modal.fieldValue.search=Rechercher
 importUsers.modal.fieldValue.noResults=Aucun utilisateur n'a été trouvé
 importUsers.modal.fieldValue.loadingResults=Chargement des résultats ...
 importUsers.modal.fieldValue.importingResults=Importer des utilisateurs  ...
+importUsers.modal.searchType.label=Rechercher dans les valeurs (plus lent)
 importUsers.modal.user.imported=Utilisateur déjà importé
 importUsers.modal.user.notImported=Utilisateur non importé
 importUsers.modal.user.failedImport=Echec d'importation de l'utilisateur

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportTranslations.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportTranslations.xml
@@ -47,6 +47,7 @@ importUsers.modal.fieldValue.search=Search
 importUsers.modal.fieldValue.noResults=No users were found for the searched value!
 importUsers.modal.fieldValue.loadingResults=Loading results ...
 importUsers.modal.fieldValue.importingResults=Importing users ...
+importUsers.modal.searchType.label=Search inside values (slower) 
 importUsers.modal.user.failedImport=Failed to import users!
 importUsers.modal.user.alreadyImported={0} already imported in
 importUsers.modal.user.created={0} user profile has been created in

--- a/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
+++ b/application-ldapuserimport-ui/src/main/resources/LDAPUserImport/LDAPUserImportUIX.xml
@@ -1076,7 +1076,7 @@ ul#importedUsersList {
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -1269,6 +1269,14 @@ ul#importedUsersList {
                 &lt;input type="text" id="searchInput" name="searchInput" required
                   placeholder="$escapetool.xml($services.localization.render('importUsers.modal.fieldValue.search'))" /&gt;
               &lt;/dd&gt;
+              &lt;dt&gt;
+                &lt;label for="searchType"&gt;
+                  $services.localization.render('importUsers.modal.searchType.label')
+                &lt;/label&gt;
+              &lt;/dt&gt;
+              &lt;dd&gt;
+                &lt;input type="checkbox" id="searchType" name="searchType" value="1" /&gt;
+              &lt;/dd&gt;
             &lt;/dl&gt;
             &lt;input type="submit" id="triggerSearch" class="btn btn-primary"
               value="$services.localization.render('importUsers.modal.fieldValue.search')"/&gt;
@@ -1379,6 +1387,14 @@ ul#importedUsersList {
               &lt;dd&gt;
                 &lt;input type="text" id="searchInput" name="searchInput" required
                   placeholder="$escapetool.xml($services.localization.render('importUsers.modal.fieldValue.search'))" /&gt;
+              &lt;/dd&gt;
+              &lt;dt&gt;
+                &lt;label for="searchType"&gt;
+                  $services.localization.render('importUsers.modal.searchType.label')
+                &lt;/label&gt;
+              &lt;/dt&gt;
+              &lt;dd&gt;
+                &lt;input type="checkbox" id="searchType" name="searchType" value="1" /&gt;
               &lt;/dd&gt;
             &lt;/dl&gt;
             &lt;input type="submit" id="triggerGroupsSearch" class="btn btn-primary"


### PR DESCRIPTION

This code allows to search in LDAP using "begin with" in both users and groups searches. An option in the search UI (checkbox) allows to make a slower "contains" search.

It has been found that on a large LDAP the "contains" search can be way to slow.
